### PR TITLE
Fix space in URL

### DIFF
--- a/space/models/api.py
+++ b/space/models/api.py
@@ -42,7 +42,7 @@ class API(db.Model):
             "url": "%s/apis/%s/%s/%s/swagger.json" % (
                 space.config["BASE_URL"],
                 self.owner,
-                self.name,
+                self.name.replace(" ", "%20"),
                 self.version)
         }  # yapf: disable
         if swagger:


### PR DESCRIPTION
Fixes #27

Replace the spaces in URL with %20 so there wont be issues with copy and paste.
